### PR TITLE
Add layout primitives

### DIFF
--- a/app/assets/global.css
+++ b/app/assets/global.css
@@ -1,4 +1,0 @@
-body {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}

--- a/app/assets/reset.css
+++ b/app/assets/reset.css
@@ -92,6 +92,7 @@ textarea {
   border: 0;
   font-family: inherit;
   font-size: 100%;
+  font-weight: unset;
   color: inherit;
   font-kerning: normal;
   text-decoration: none;

--- a/app/src/App.re
+++ b/app/src/App.re
@@ -23,8 +23,8 @@ module Styles = {
   let container =
     style([
       display(grid),
-      unsafe("gridTemplateColumns", "repeat(8, 1fr)"),
-      unsafe("gridTemplateRows", "repeat(8, 1fr)"),
+      gridTemplateColumns([`repeat((`num(8), `fr(1.0)))]),
+      gridTemplateRows([`repeat((`num(8), `fr(1.0)))]),
       gridGap(px(24)),
       height(vh(100.0)),
     ]);

--- a/app/src/App.re
+++ b/app/src/App.re
@@ -4,8 +4,8 @@ module Styles = {
   global(
     "body",
     [
-      unsafe("-webkit-font-smoothing", "antialiased"),
-      unsafe("-moz-osx-font-smoothing", "grayscale"),
+      unsafe(" -webkit-font-smoothing", "antialiased"),
+      unsafe(" -moz-osx-font-smoothing", "grayscale"),
       color(Particle.Color.black()),
       ...Particle.Font.text,
     ],
@@ -24,7 +24,7 @@ module Styles = {
     style([
       display(grid),
       unsafe("gridTemplateColumns", "repeat(8, 1fr)"),
-      unsafe("grid-template-rows", "repeat(8, 1fr)"),
+      unsafe("gridTemplateRows", "repeat(8, 1fr)"),
       gridGap(px(24)),
       height(vh(100.0)),
     ]);

--- a/app/src/App.re
+++ b/app/src/App.re
@@ -1,7 +1,15 @@
 module Styles = {
   open Css;
 
-  global("body", [color(Particle.Color.black()), ...Particle.Font.text]);
+  global(
+    "body",
+    [
+      unsafe("-webkit-font-smoothing", "antialiased"),
+      unsafe("-moz-osx-font-smoothing", "grayscale"),
+      color(Particle.Color.black()),
+      ...Particle.Font.text,
+    ],
+  );
 
   global(
     "a",
@@ -11,6 +19,23 @@ module Styles = {
       cursor(`pointer),
     ],
   );
+
+  let container =
+    style([
+      display(grid),
+      unsafe("gridTemplateColumns", "repeat(8, 1fr)"),
+      unsafe("grid-template-rows", "repeat(8, 1fr)"),
+      gridGap(px(24)),
+      height(vh(100.0)),
+    ]);
+
+  let content =
+    style([
+      marginTop(px(50)),
+      gridColumnStart(3),
+      gridColumnEnd(7),
+      height(pct(100.0)),
+    ]);
 };
 
 [@react.component]
@@ -28,5 +53,9 @@ let make = () => {
     | NotFound(_path) => <Generic title="Not Found" />
     };
 
-  <div> <Topbar /> page <Footer /> </div>;
+  <div className=Styles.container>
+    <Topbar />
+    <div className=Styles.content> page </div>
+    <Footer />
+  </div>;
 };

--- a/app/src/App.re
+++ b/app/src/App.re
@@ -30,12 +30,7 @@ module Styles = {
     ]);
 
   let content =
-    style([
-      marginTop(px(50)),
-      gridColumnStart(3),
-      gridColumnEnd(7),
-      height(pct(100.0)),
-    ]);
+    style([gridColumnStart(3), gridColumnEnd(7), height(pct(100.0))]);
 };
 
 [@react.component]

--- a/app/src/App.re
+++ b/app/src/App.re
@@ -4,9 +4,9 @@ module Styles = {
   global(
     "body",
     [
+      color(Particle.Color.black()),
       unsafe(" -webkit-font-smoothing", "antialiased"),
       unsafe(" -moz-osx-font-smoothing", "grayscale"),
-      color(Particle.Color.black()),
       ...Particle.Font.text,
     ],
   );
@@ -15,8 +15,8 @@ module Styles = {
     "a",
     [
       color(Particle.Color.black()),
-      textDecoration(none),
       cursor(`pointer),
+      textDecoration(none),
     ],
   );
 
@@ -30,7 +30,7 @@ module Styles = {
     ]);
 
   let content =
-    style([gridColumnStart(3), gridColumnEnd(7), height(pct(100.0))]);
+    style([gridColumnEnd(7), gridColumnStart(3), height(pct(100.0))]);
 };
 
 [@react.component]

--- a/app/src/Footer.re
+++ b/app/src/Footer.re
@@ -3,12 +3,12 @@ module Styles = {
 
   let footer =
     style([
+      display(grid),
       gridColumnStart(2),
       gridColumnEnd(8),
       gridRowStart(-1),
       height(px(64)),
       justifySelf(center),
-      display(grid),
     ]);
 
   let ul =

--- a/app/src/Footer.re
+++ b/app/src/Footer.re
@@ -1,6 +1,3 @@
-open Router;
-open Atom;
-
 module Styles = {
   open Css;
 
@@ -10,36 +7,26 @@ module Styles = {
       gridColumnEnd(8),
       gridRowStart(-1),
       height(px(64)),
-      display(`flex),
-      justifyContent(`center),
-      unsafe("placeSelf", "end stretch"),
+      justifySelf(center),
+      display(grid),
     ]);
 
-  let li = style([marginLeft(px(24)), display(inline)]);
+  let ul =
+    style([
+      children([marginRight(px(24)), display(inline), alignSelf(center)]),
+      alignSelf(center),
+    ]);
 };
 
 [@react.component]
 let make = () =>
   <footer className=Styles.footer>
-    <Link page=Root> <Atom.Icon.Logo /> </Link>
-    <ul>
-      <li className=Styles.li>
-        <a href="/"> {React.string("What is oscoin?")} </a>
-      </li>
-      <li className=Styles.li>
-        <a href="/"> {React.string("Maintainers")} </a>
-      </li>
-      <li className=Styles.li>
-        <a href="/"> {React.string("Contributors")} </a>
-      </li>
-      <li className=Styles.li>
-        <a href="/"> {React.string("Supporters")} </a>
-      </li>
-      <li className=Styles.li>
-        <a href="/"> {React.string("Security")} </a>
-      </li>
-      <li className=Styles.li>
-        <a href="/"> {React.string("Privacy")} </a>
-      </li>
+    <ul className=Styles.ul>
+      <li> <a href="/"> {React.string("What is oscoin?")} </a> </li>
+      <li> <a href="/"> {React.string("Maintainers")} </a> </li>
+      <li> <a href="/"> {React.string("Contributors")} </a> </li>
+      <li> <a href="/"> {React.string("Supporters")} </a> </li>
+      <li> <a href="/"> {React.string("Security")} </a> </li>
+      <li> <a href="/"> {React.string("Privacy")} </a> </li>
     </ul>
   </footer>;

--- a/app/src/Footer.re
+++ b/app/src/Footer.re
@@ -12,7 +12,7 @@ module Styles = {
       height(px(64)),
       display(`flex),
       justifyContent(`center),
-      unsafe("place-self", "end stretch"),
+      unsafe("placeSelf", "end stretch"),
     ]);
 
   let li = style([marginLeft(px(24)), display(inline)]);

--- a/app/src/Footer.re
+++ b/app/src/Footer.re
@@ -6,10 +6,13 @@ module Styles = {
 
   let footer =
     style([
+      gridColumnStart(2),
+      gridColumnEnd(8),
+      gridRowStart(-1),
+      height(px(64)),
       display(`flex),
-      justifyContent(`spaceAround),
-      alignItems(`center),
-      height(px(118)),
+      justifyContent(`center),
+      unsafe("place-self", "end stretch"),
     ]);
 
   let li = style([marginLeft(px(24)), display(inline)]);

--- a/app/src/Molecule.re
+++ b/app/src/Molecule.re
@@ -13,6 +13,7 @@ module Styles = {
       padding(px(13)),
       borderBottom(px(1), solid, Color.lightGray()),
       lastChild([borderBottomWidth(px(0))]),
+      hover([backgroundColor(Color.almostWhite())]),
     ]);
 
   let description =

--- a/app/src/Molecule.re
+++ b/app/src/Molecule.re
@@ -1,4 +1,3 @@
-open Source.Project;
 open Atom;
 open Particle;
 
@@ -23,22 +22,18 @@ module Styles = {
       justifyContent(`center),
     ]);
 
-  let link = style([display(`flex)]);
-
   let image =
     style([marginRight(px(21)), width(px(64)), height(px(64))]);
 };
 
 module ProjectCard = {
   [@react.component]
-  let make = (~project) =>
-    <li className=Styles.item key={project.address}>
-      <Link style=Styles.link page={Router.Project(project.address)}>
-        <img className=Styles.image src={project.imgUrl} />
-        <div className=Styles.description>
-          <Title> {React.string(project.name)} </Title>
-          <Text> {React.string(project.description)} </Text>
-        </div>
-      </Link>
-    </li>;
+  let make = (~imgUrl, ~name, ~description) =>
+    <div className=Styles.item>
+      <img className=Styles.image src=imgUrl />
+      <div className=Styles.description>
+        <Title> {React.string(name)} </Title>
+        <Text> {React.string(description)} </Text>
+      </div>
+    </div>;
 };

--- a/app/src/Molecule.re
+++ b/app/src/Molecule.re
@@ -7,13 +7,13 @@ module ProjectCard = {
 
     let item =
       style([
-        width(pct(100.0)),
+        borderBottom(px(1), solid, Color.lightGray()),
         display(`flex),
         flex(`num(1.0)),
         padding(px(13)),
-        borderBottom(px(1), solid, Color.lightGray()),
-        lastChild([borderBottomWidth(px(0))]),
+        width(pct(100.0)),
         hover([backgroundColor(Color.almostWhite())]),
+        lastChild([borderBottomWidth(px(0))]),
       ]);
 
     let description =
@@ -24,7 +24,7 @@ module ProjectCard = {
       ]);
 
     let image =
-      style([marginRight(px(21)), width(px(64)), height(px(64))]);
+      style([height(px(64)), marginRight(px(21)), width(px(64))]);
   };
 
   [@react.component]

--- a/app/src/Molecule.re
+++ b/app/src/Molecule.re
@@ -1,0 +1,43 @@
+open Source.Project;
+open Atom;
+open Particle;
+
+module Styles = {
+  open Css;
+
+  let item =
+    style([
+      width(pct(100.0)),
+      display(`flex),
+      flex(`num(1.0)),
+      padding(px(13)),
+      borderBottom(px(1), solid, Color.lightGray()),
+      lastChild([borderBottomWidth(px(0))]),
+    ]);
+
+  let description =
+    style([
+      display(`flex),
+      flexDirection(`column),
+      justifyContent(`center),
+    ]);
+
+  let link = style([display(`flex)]);
+
+  let image =
+    style([marginRight(px(21)), width(px(64)), height(px(64))]);
+};
+
+module ProjectCard = {
+  [@react.component]
+  let make = (~project) =>
+    <li className=Styles.item key={project.address}>
+      <Link style=Styles.link page={Router.Project(project.address)}>
+        <img className=Styles.image src={project.imgUrl} />
+        <div className=Styles.description>
+          <Title> {React.string(project.name)} </Title>
+          <p> {React.string(project.description)} </p>
+        </div>
+      </Link>
+    </li>;
+};

--- a/app/src/Molecule.re
+++ b/app/src/Molecule.re
@@ -36,7 +36,7 @@ module ProjectCard = {
         <img className=Styles.image src={project.imgUrl} />
         <div className=Styles.description>
           <Title> {React.string(project.name)} </Title>
-          <p> {React.string(project.description)} </p>
+          <Text> {React.string(project.description)} </Text>
         </div>
       </Link>
     </li>;

--- a/app/src/Molecule.re
+++ b/app/src/Molecule.re
@@ -1,32 +1,32 @@
-open Atom;
-open Particle;
-
-module Styles = {
-  open Css;
-
-  let item =
-    style([
-      width(pct(100.0)),
-      display(`flex),
-      flex(`num(1.0)),
-      padding(px(13)),
-      borderBottom(px(1), solid, Color.lightGray()),
-      lastChild([borderBottomWidth(px(0))]),
-      hover([backgroundColor(Color.almostWhite())]),
-    ]);
-
-  let description =
-    style([
-      display(`flex),
-      flexDirection(`column),
-      justifyContent(`center),
-    ]);
-
-  let image =
-    style([marginRight(px(21)), width(px(64)), height(px(64))]);
-};
-
 module ProjectCard = {
+  open Atom;
+  open Particle;
+
+  module Styles = {
+    open Css;
+
+    let item =
+      style([
+        width(pct(100.0)),
+        display(`flex),
+        flex(`num(1.0)),
+        padding(px(13)),
+        borderBottom(px(1), solid, Color.lightGray()),
+        lastChild([borderBottomWidth(px(0))]),
+        hover([backgroundColor(Color.almostWhite())]),
+      ]);
+
+    let description =
+      style([
+        display(`flex),
+        flexDirection(`column),
+        justifyContent(`center),
+      ]);
+
+    let image =
+      style([marginRight(px(21)), width(px(64)), height(px(64))]);
+  };
+
   [@react.component]
   let make = (~imgUrl, ~name, ~description) =>
     <div className=Styles.item>

--- a/app/src/Topbar.re
+++ b/app/src/Topbar.re
@@ -9,7 +9,6 @@ module Styles = {
       gridColumnStart(2),
       gridColumnEnd(8),
       height(px(64)),
-      display(`flex),
       paddingTop(px(32)),
     ]);
 };

--- a/app/src/Topbar.re
+++ b/app/src/Topbar.re
@@ -1,14 +1,16 @@
 open Atom;
+open Layout;
 
 module Styles = {
   open Css;
 
-  let topBar =
+  let header =
     style([
+      gridColumnStart(2),
+      gridColumnEnd(8),
+      height(px(64)),
       display(`flex),
-      justifyContent(`spaceAround),
-      alignItems(`center),
-      height(px(118)),
+      paddingTop(px(32)),
     ]);
 };
 
@@ -32,9 +34,12 @@ module Navigation = {
 [@react.component]
 let make = () =>
   Router.(
-    <header className=Styles.topBar>
-      <Link page=Root> <Atom.Icon.Logo /> </Link>
-      <Navigation />
-      <JoinNetwork />
+    <header className=Styles.header>
+      <Container.TwoColumns>
+        ...(
+             <> <Link page=Root> <Atom.Icon.Logo /> </Link> <Navigation /> </>,
+             <JoinNetwork />,
+           )
+      </Container.TwoColumns>
     </header>
   );

--- a/app/src/atoms/Atom.re
+++ b/app/src/atoms/Atom.re
@@ -2,3 +2,4 @@ module Icon = AtomIcon;
 module Button = AtomButton;
 module Title = AtomTitle;
 module Link = AtomLink;
+module Layout = AtomLayout;

--- a/app/src/atoms/Atom.re
+++ b/app/src/atoms/Atom.re
@@ -1,5 +1,6 @@
 module Icon = AtomIcon;
 module Button = AtomButton;
 module Title = AtomTitle;
+module Text = AtomText;
 module Link = AtomLink;
 module Layout = AtomLayout;

--- a/app/src/atoms/AtomButton.re
+++ b/app/src/atoms/AtomButton.re
@@ -5,14 +5,14 @@ module Styles = {
   let button =
     merge([
       style([
-        color(Color.black()),
+        color(Color.darkGray()),
         backgroundColor(Color.white()),
         hover([backgroundColor(Color.almostWhite(~alpha=0.85, ()))]),
         active([backgroundColor(Color.almostWhite(~alpha=0.2, ()))]),
         borderRadius(px(4)),
         borderStyle(solid),
         borderWidth(px(1)),
-        borderColor(Color.black()),
+        borderColor(Color.lightGray()),
         outlineStyle(`none),
         height(px(48)),
         padding4(
@@ -54,9 +54,9 @@ module Styles = {
       button,
       style([
         borderStyle(none),
-        backgroundColor(Color.grey()),
-        hover([backgroundColor(Color.grey())]),
-        active([backgroundColor(Color.grey())]),
+        backgroundColor(Color.gray()),
+        hover([backgroundColor(Color.gray())]),
+        active([backgroundColor(Color.gray())]),
       ]),
     ]);
 };

--- a/app/src/atoms/AtomButton.re
+++ b/app/src/atoms/AtomButton.re
@@ -5,22 +5,22 @@ module Styles = {
   let button =
     merge([
       style([
-        color(Color.darkGray()),
         backgroundColor(Color.white()),
-        hover([backgroundColor(Color.almostWhite(~alpha=0.85, ()))]),
-        active([backgroundColor(Color.almostWhite(~alpha=0.2, ()))]),
         borderRadius(px(4)),
         borderStyle(solid),
         borderWidth(px(1)),
         borderColor(Color.lightGray()),
-        outlineStyle(`none),
+        color(Color.darkGray()),
         height(px(48)),
+        outlineStyle(`none),
         padding4(
           ~top=px(13),
           ~right=px(24),
           ~bottom=px(14),
           ~left=px(24),
         ),
+        active([backgroundColor(Color.almostWhite(~alpha=0.2, ()))]),
+        hover([backgroundColor(Color.almostWhite(~alpha=0.85, ()))]),
       ]),
       style(Font.title),
     ]);
@@ -32,8 +32,8 @@ module Styles = {
         borderStyle(none),
         color(Color.white()),
         backgroundColor(Color.purple()),
-        hover([backgroundColor(Color.purple(~alpha=0.85, ()))]),
         active([backgroundColor(Color.purple(~alpha=0.75, ()))]),
+        hover([backgroundColor(Color.purple(~alpha=0.85, ()))]),
       ]),
     ]);
 
@@ -44,8 +44,8 @@ module Styles = {
         borderStyle(none),
         color(Color.white()),
         backgroundColor(Color.pink()),
-        hover([backgroundColor(Color.pink(~alpha=0.85, ()))]),
         active([backgroundColor(Color.pink(~alpha=0.75, ()))]),
+        hover([backgroundColor(Color.pink(~alpha=0.85, ()))]),
       ]),
     ]);
 
@@ -53,10 +53,10 @@ module Styles = {
     merge([
       button,
       style([
-        borderStyle(none),
         backgroundColor(Color.gray()),
-        hover([backgroundColor(Color.gray())]),
+        borderStyle(none),
         active([backgroundColor(Color.gray())]),
+        hover([backgroundColor(Color.gray())]),
       ]),
     ]);
 };

--- a/app/src/atoms/AtomLayout.re
+++ b/app/src/atoms/AtomLayout.re
@@ -9,10 +9,12 @@ module Styles = {
   let twoColumns = style([display(`flex), flex(`num(1.0))]);
 };
 
+type tuple2Children = (ReasonReact.reactElement, ReasonReact.reactElement);
+
 module Container = {
   module TwoColumns = {
     [@react.component]
-    let make = (~children) =>
+    let make = (~children: tuple2Children) =>
       <div className=Styles.twoColumns>
         <div className=Styles.left> {fst(children)} </div>
         <div className=Styles.right> {snd(children)} </div>

--- a/app/src/atoms/AtomLayout.re
+++ b/app/src/atoms/AtomLayout.re
@@ -4,10 +4,10 @@ module Container = {
   module Styles = {
     open Css;
 
-    let left = style([flex(`num(1.0)), display(`flex)]);
+    let left = style([display(`flex), flex(`num(1.0))]);
 
     let right =
-      style([flex(`num(1.0)), display(`flex), justifyContent(flexEnd)]);
+      style([display(`flex), flex(`num(1.0)), justifyContent(flexEnd)]);
 
     let twoColumns = style([display(`flex), flex(`num(1.0))]);
   };

--- a/app/src/atoms/AtomLayout.re
+++ b/app/src/atoms/AtomLayout.re
@@ -1,17 +1,17 @@
-module Styles = {
-  open Css;
-
-  let left = style([flex(`num(1.0)), display(`flex)]);
-
-  let right =
-    style([flex(`num(1.0)), display(`flex), justifyContent(flexEnd)]);
-
-  let twoColumns = style([display(`flex), flex(`num(1.0))]);
-};
-
 type tuple2Children = (ReasonReact.reactElement, ReasonReact.reactElement);
 
 module Container = {
+  module Styles = {
+    open Css;
+
+    let left = style([flex(`num(1.0)), display(`flex)]);
+
+    let right =
+      style([flex(`num(1.0)), display(`flex), justifyContent(flexEnd)]);
+
+    let twoColumns = style([display(`flex), flex(`num(1.0))]);
+  };
+
   module TwoColumns = {
     [@react.component]
     let make = (~children: tuple2Children) =>

--- a/app/src/atoms/AtomLayout.re
+++ b/app/src/atoms/AtomLayout.re
@@ -1,0 +1,21 @@
+module Styles = {
+  open Css;
+
+  let left = style([flex(`num(1.0)), display(`flex)]);
+
+  let right =
+    style([flex(`num(1.0)), display(`flex), justifyContent(flexEnd)]);
+
+  let twoColumns = style([display(`flex), flex(`num(1.0))]);
+};
+
+module Container = {
+  module TwoColumns = {
+    [@react.component]
+    let make = (~children) =>
+      <div className=Styles.twoColumns>
+        <div className=Styles.left> {fst(children)} </div>
+        <div className=Styles.right> {snd(children)} </div>
+      </div>;
+  };
+};

--- a/app/src/atoms/AtomLink.re
+++ b/app/src/atoms/AtomLink.re
@@ -1,12 +1,23 @@
 open Router;
+open Css;
+
+module Styles = {
+  let link = style([]);
+};
 
 [@react.component]
-let make = (~page: page, ~children=?) => {
+let make = (~page: page, ~style=?, ~children=?) => {
   let content =
     switch (children) {
     | Some(child) => child
     | None => React.string(nameOfPage(page))
     };
 
-  <a onClick={navigateOfPage(page)}> content </a>;
+  let style =
+    switch (style) {
+    | Some(style) => merge([Styles.link, style])
+    | None => Styles.link
+    };
+
+  <a onClick={navigateOfPage(page)} className=style> content </a>;
 };

--- a/app/src/atoms/AtomText.re
+++ b/app/src/atoms/AtomText.re
@@ -1,0 +1,10 @@
+module Styles = {
+  open Css;
+  open Particle;
+
+  let regular =
+    merge([style([color(Color.darkGray())]), style(Particle.Font.text)]);
+};
+
+[@react.component]
+let make = (~children) => <p className=Styles.regular> children </p>;

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <title>Oscoin MVP</title>
   <link rel="stylesheet" href="/reset.css" type="text/css" media="screen">
-  <link rel="stylesheet" href="/global.css" type="text/css" media="screen">
 </head>
 <body>
   <div id="app"></div>

--- a/app/src/pages/PageProjects.re
+++ b/app/src/pages/PageProjects.re
@@ -1,7 +1,7 @@
 open Source.Project;
-open Router;
 open Atom;
 open Layout;
+open Molecule;
 
 module Styles = {
   open Css;
@@ -17,18 +17,7 @@ module Styles = {
 module List = {
   [@react.component]
   let make = (~projects: array(project)) => {
-    let ps =
-      Array.map(
-        project =>
-          <li className=Styles.item key={project.address}>
-            <Link page={Project(project.address)}>
-              <Title> {React.string(project.name)} </Title>
-              <p> {React.string(project.description)} </p>
-              <img src={project.imgUrl} />
-            </Link>
-          </li>,
-        projects,
-      );
+    let ps = Array.map(project => <ProjectCard project />, projects);
 
     <ul> {React.array(ps)} </ul>;
   };

--- a/app/src/pages/PageProjects.re
+++ b/app/src/pages/PageProjects.re
@@ -7,12 +7,24 @@ module Styles = {
   open Css;
 
   let projectHeading = style([marginTop(px(94)), marginBottom(px(48))]);
+  let link = style([display(`flex)]);
 };
 
 module List = {
   [@react.component]
   let make = (~projects: array(project)) => {
-    let ps = Array.map(project => <ProjectCard project />, projects);
+    let ps =
+      Array.map(
+        project =>
+          <Link style=Styles.link page={Router.Project(project.address)}>
+            <ProjectCard
+              imgUrl={project.imgUrl}
+              name={project.name}
+              description={project.description}
+            />
+          </Link>,
+        projects,
+      );
 
     <ul> {React.array(ps)} </ul>;
   };

--- a/app/src/pages/PageProjects.re
+++ b/app/src/pages/PageProjects.re
@@ -7,7 +7,6 @@ module Styles = {
   open Css;
 
   let projectHeading = style([marginTop(px(94)), marginBottom(px(48))]);
-  let link = style([]);
 };
 
 module List = {
@@ -16,7 +15,7 @@ module List = {
     let ps =
       Array.map(
         project =>
-          <Link style=Styles.link page={Router.Project(project.address)}>
+          <Link page={Router.Project(project.address)}>
             <ProjectCard
               imgUrl={project.imgUrl}
               name={project.name}

--- a/app/src/pages/PageProjects.re
+++ b/app/src/pages/PageProjects.re
@@ -7,7 +7,7 @@ module Styles = {
   open Css;
 
   let projectHeading = style([marginTop(px(94)), marginBottom(px(48))]);
-  let link = style([display(`flex)]);
+  let link = style([]);
 };
 
 module List = {

--- a/app/src/pages/PageProjects.re
+++ b/app/src/pages/PageProjects.re
@@ -1,6 +1,18 @@
 open Source.Project;
 open Router;
 open Atom;
+open Layout;
+
+module Styles = {
+  open Css;
+
+  let item =
+    style([
+      margin(px(16)),
+      borderBottom(px(1), solid, gray),
+      lastChild([borderWidth(px(0))]),
+    ]);
+};
 
 module List = {
   [@react.component]
@@ -8,7 +20,7 @@ module List = {
     let ps =
       Array.map(
         project =>
-          <li key={project.address}>
+          <li className=Styles.item key={project.address}>
             <Link page={Project(project.address)}>
               <Title> {React.string(project.name)} </Title>
               <p> {React.string(project.description)} </p>
@@ -52,10 +64,12 @@ let make = () => {
   });
 
   <>
-    <div>
-      <Title.Huge> {React.string("Explore")} </Title.Huge>
-      <Button> {React.string("Register project")} </Button>
-    </div>
+    <Container.TwoColumns>
+      ...(
+           <Title.Huge> {React.string("Explore")} </Title.Huge>,
+           <Button> {React.string("Register project")} </Button>,
+         )
+    </Container.TwoColumns>
     {
       switch (state) {
       | Loading => <div> {React.string("Loading...")} </div>

--- a/app/src/pages/PageProjects.re
+++ b/app/src/pages/PageProjects.re
@@ -6,7 +6,7 @@ open Molecule;
 module Styles = {
   open Css;
 
-  let projectHeading = style([marginTop(px(94)), marginBottom(px(48))]);
+  let projectHeading = style([marginBottom(px(48)), marginTop(px(94))]);
 };
 
 module List = {

--- a/app/src/pages/PageProjects.re
+++ b/app/src/pages/PageProjects.re
@@ -6,12 +6,7 @@ open Molecule;
 module Styles = {
   open Css;
 
-  let item =
-    style([
-      margin(px(16)),
-      borderBottom(px(1), solid, gray),
-      lastChild([borderWidth(px(0))]),
-    ]);
+  let projectHeading = style([marginTop(px(94)), marginBottom(px(48))]);
 };
 
 module List = {
@@ -53,12 +48,14 @@ let make = () => {
   });
 
   <>
-    <Container.TwoColumns>
-      ...(
-           <Title.Huge> {React.string("Explore")} </Title.Huge>,
-           <Button> {React.string("Register project")} </Button>,
-         )
-    </Container.TwoColumns>
+    <div className=Styles.projectHeading>
+      <Container.TwoColumns>
+        ...(
+             <Title.Huge> {React.string("Explore")} </Title.Huge>,
+             <Button> {React.string("Register project")} </Button>,
+           )
+      </Container.TwoColumns>
+    </div>
     {
       switch (state) {
       | Loading => <div> {React.string("Loading...")} </div>

--- a/app/src/particles/ParticleColor.re
+++ b/app/src/particles/ParticleColor.re
@@ -17,8 +17,8 @@ let pink = (~alpha=1.0, ()) => rgba(224, 116, 203, alpha);
 
 /** Grays **/
 let black = (~alpha=1.0, ()) => rgba(40, 51, 61, alpha);
-let darkGrey = (~alpha=1.0, ()) => rgba(84, 100, 116, alpha);
-let grey = (~alpha=1.0, ()) => rgba(144, 160, 174, alpha);
-let lightGray = (~alpha=1.0, ()) => rgba(206, 216, 255, alpha);
+let darkGray = (~alpha=1.0, ()) => rgba(84, 100, 116, alpha);
+let gray = (~alpha=1.0, ()) => rgba(144, 160, 174, alpha);
+let lightGray = (~alpha=1.0, ()) => rgba(206, 216, 225, alpha);
 let almostWhite = (~alpha=1.0, ()) => rgba(248, 248, 248, alpha);
 let white = (~alpha=1.0, ()) => rgba(255, 255, 255, alpha);

--- a/app/src/particles/ParticleColor.re
+++ b/app/src/particles/ParticleColor.re
@@ -1,24 +1,24 @@
 open Css;
 
 /** Primaries **/
-let purple = (~alpha=1.0, ()) => rgba(120, 52, 232, alpha);
-let blue = (~alpha=1.0, ()) => rgba(0, 146, 210, alpha);
-let green = (~alpha=1.0, ()) => rgba(0, 217, 110, alpha);
-let orange = (~alpha=1.0, ()) => rgba(254, 190, 0, alpha);
-let red = (~alpha=1.0, ()) => rgba(250, 64, 72, alpha);
-let bordeaux = (~alpha=1.0, ()) => rgba(207, 56, 107, alpha);
+let purple = (~alpha=1.0, ()) => rgba(110, 72, 221, alpha);
+let blue = (~alpha=1.0, ()) => rgba(41, 146, 202, alpha);
+let green = (~alpha=1.0, ()) => rgba(48, 210, 124, alpha);
+let orange = (~alpha=1.0, ()) => rgba(244, 190, 69, alpha);
+let red = (~alpha=1.0, ()) => rgba(229, 81, 84, alpha);
+let bordeaux = (~alpha=1.0, ()) => rgba(189, 71, 108, alpha);
 
 /** Secondaries **/
-let lightBlue = (~alpha=1.0, ()) => rgba(153, 159, 240, alpha);
-let teal = (~alpha=1.0, ()) => rgba(0, 229, 248, alpha);
-let lightGreen = (~alpha=1.0, ()) => rgba(0, 249, 126, alpha);
-let yellow = (~alpha=1.0, ()) => rgba(223, 239, 0, alpha);
-let pink = (~alpha=1.0, ()) => rgba(224, 116, 203, alpha);
+let lightBlue = (~alpha=1.0, ()) => rgba(154, 161, 237, alpha);
+let teal = (~alpha=1.0, ()) => rgba(89, 226, 243, alpha);
+let lightGreen = (~alpha=1.0, ()) => rgba(55, 241, 143, alpha);
+let yellow = (~alpha=1.0, ()) => rgba(227, 235, 55, alpha);
+let pink = (~alpha=1.0, ()) => rgba(222, 119, 201, alpha);
 
 /** Grays **/
 let black = (~alpha=1.0, ()) => rgba(40, 51, 61, alpha);
-let darkGray = (~alpha=1.0, ()) => rgba(84, 100, 116, alpha);
-let gray = (~alpha=1.0, ()) => rgba(144, 160, 174, alpha);
+let darkGray = (~alpha=1.0, ()) => rgba(85, 100, 115, alpha);
+let gray = (~alpha=1.0, ()) => rgba(145, 160, 174, alpha);
 let lightGray = (~alpha=1.0, ()) => rgba(206, 216, 225, alpha);
 let almostWhite = (~alpha=1.0, ()) => rgba(248, 248, 248, alpha);
 let white = (~alpha=1.0, ()) => rgba(255, 255, 255, alpha);

--- a/app/src/particles/ParticleFont.re
+++ b/app/src/particles/ParticleFont.re
@@ -57,7 +57,7 @@ let bigTitle = [
 ];
 
 let title = [
-  fontFamily(gtMedium),
+  fontFamily(gtRegular),
   fontSize(px(16)),
   lineHeight(`percent(130.0)),
 ];

--- a/app/src/particles/ParticleFont.re
+++ b/app/src/particles/ParticleFont.re
@@ -57,7 +57,7 @@ let bigTitle = [
 ];
 
 let title = [
-  fontFamily(gtRegular),
+  fontFamily(gtMedium),
   fontSize(px(16)),
   lineHeight(`percent(130.0)),
 ];


### PR DESCRIPTION
Start extracting repeated layout patterns into design system primitives. We'll use these to position and align components on a page as well as apply different sizing to containers.