### PR TITLE
Setup CI powered by buildkite

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:12.8.1
+
+# RUN apk add --update g++ python
+RUN yarn global add bs-platform@5.1.0 reason-cli

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,5 +1,7 @@
+env:
+  HOME: '/build'
+
 steps:
   - command: 'yarn && cd app && yarn test'
     env:
       DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.0'
-      HOME: '/build'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -5,8 +5,6 @@ steps:
   - commands:
     - 'export HOME=/cache'
     - 'export YARN_CACHE_FOLDER=/cache'
-    - 'env'
     - 'cd app'
-    - 'ls -lah'
     - 'yarn'
     - 'yarn test'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,7 +3,7 @@ env:
 
 steps:
   - commands:
-    - 'export HOME=build'
+    - 'export HOME=/cache'
     - 'export YARN_CACHE_FOLDER=/cache'
     - 'env'
     - 'cd app'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,6 +4,10 @@ env:
 
 steps:
   - commands:
+    - 'export HOME=build'
+    - 'export YARN_CACHE_FOLDER=/cache'
     - 'env'
-    - 'cd app && HOME=/build YARN_CACHE_FOLDER=/cache yarn'
-    - 'cd app && HOME=/build YARN_CACHE_FOLDER=/cache yarn test'
+    - 'cd app'
+    - 'ls -lah'
+    - 'yarn'
+    - 'yarn test'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
     command: 'env'
 
   - label: 'dependencies'
-    command: 'cd /app && HOME=/build YARN_CACHE_FOLDER=/cache yarn'
+    command: 'cd app && HOME=/build YARN_CACHE_FOLDER=/cache yarn'
     
   - label: 'tests'
-    command: 'cd /app && HOME=/build YARN_CACHE_FOLDER=/cache yarn test'
+    command: 'cd app && HOME=/build YARN_CACHE_FOLDER=/cache yarn test'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,4 +1,4 @@
 steps:
-  - command: 'cd app && yarn test'
+  - command: 'yarn && cd app && yarn test'
     env:
       DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.0'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
     command: 'env'
 
   - label: 'dependencies'
-    command: 'HOME=/build YARN_CACHE_FOLDER=/cache yarn'
+    command: 'HOME=/build YARN_CACHE_FOLDER=/cache cd app && yarn'
     
   - label: 'tests'
     command: 'HOME=/build YARN_CACHE_FOLDER=/cache cd app && yarn test'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,4 @@
+steps:
+  - command: 'yarn test'
+    env:
+      DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.0'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,7 +1,13 @@
 env:
+  DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.0'
   HOME: '/build'
 
 steps:
-  - command: 'yarn && cd app && yarn test'
-    env:
-      DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.0'
+  - label: 'ENV'
+    command: 'env'
+
+  - label: 'dependencies'
+    command: 'YARN_CACHE_FOLDER=/cache yarn'
+    
+  - label: 'tests'
+    command: 'YARN_CACHE_FOLDER=/cache cd app && yarn test'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
     command: 'env'
 
   - label: 'dependencies'
-    command: 'HOME=/build YARN_CACHE_FOLDER=/cache cd app && yarn'
+    command: 'cd /app && HOME=/build YARN_CACHE_FOLDER=/cache yarn'
     
   - label: 'tests'
-    command: 'HOME=/build YARN_CACHE_FOLDER=/cache cd app && yarn test'
+    command: 'cd /app && HOME=/build YARN_CACHE_FOLDER=/cache yarn test'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,4 +1,4 @@
 steps:
-  - command: 'yarn test'
+  - command: 'cd app && yarn test'
     env:
       DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.0'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,3 +2,4 @@ steps:
   - command: 'yarn && cd app && yarn test'
     env:
       DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.0'
+      HOME: '/build'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,5 @@
 env:
   DOCKER_IMAGE: 'gcr.io/opensourcecoin/mvp:0.1.0'
-  HOME: '/build'
 
 steps:
   - commands:

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,7 +7,7 @@ steps:
     command: 'env'
 
   - label: 'dependencies'
-    command: 'YARN_CACHE_FOLDER=/cache yarn'
+    command: 'HOME=/build YARN_CACHE_FOLDER=/cache yarn'
     
   - label: 'tests'
-    command: 'YARN_CACHE_FOLDER=/cache cd app && yarn test'
+    command: 'HOME=/build YARN_CACHE_FOLDER=/cache cd app && yarn test'

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -3,11 +3,7 @@ env:
   HOME: '/build'
 
 steps:
-  - label: 'ENV'
-    command: 'env'
-
-  - label: 'dependencies'
-    command: 'cd app && HOME=/build YARN_CACHE_FOLDER=/cache yarn'
-    
-  - label: 'tests'
-    command: 'cd app && HOME=/build YARN_CACHE_FOLDER=/cache yarn test'
+  - commands:
+    - 'env'
+    - 'cd app && HOME=/build YARN_CACHE_FOLDER=/cache yarn'
+    - 'cd app && HOME=/build YARN_CACHE_FOLDER=/cache yarn test'


### PR DESCRIPTION
Sets up minimal build pipeline utilising yarn to cache dependencies and run the bare test command. Ideally this could be extended to capture coverage.

* build custom docker image to our Reason codebase
* implement buildkite pipeline