### PR TITLE
Fix project list items

### DIFF
--- a/app/src/pages/PageProjects.re
+++ b/app/src/pages/PageProjects.re
@@ -15,13 +15,15 @@ module List = {
     let ps =
       Array.map(
         project =>
-          <Link page={Router.Project(project.address)}>
-            <ProjectCard
-              imgUrl={project.imgUrl}
-              name={project.name}
-              description={project.description}
-            />
-          </Link>,
+          <li key={project.address}>
+            <Link page={Router.Project(project.address)}>
+              <ProjectCard
+                imgUrl={project.imgUrl}
+                name={project.name}
+                description={project.description}
+              />
+            </Link>
+          </li>,
         projects,
       );
 


### PR DESCRIPTION
List items in React are required to have a unique key assigned for the underlying diffing algorithm to work properly and compute which elements need redrawing. We also missed the `li` for the enclosing `ul`, just a small semantic fix on top.

* add key prop to project list items
* wrap list item in `li`