### PR TITLE
Store mock key in browser's localstorage

### DIFF
--- a/app/src/Source.re
+++ b/app/src/Source.re
@@ -12,11 +12,18 @@ type source = {
   fetchAccount: unit => Js.Promise.t(fetchAccountResult),
 };
 
+module StorageLabel = {
+  let keyName = "keyName";
+  let avatarUrl = "avatarUrl";
+};
+
 let createLocalSource = () => {
   let createAccount = (keyName, avatarUrl) =>
     Js.Promise.make((~resolve, ~reject as _) => {
-      Dom.Storage.(localStorage |> setItem("keyName", keyName));
-      Dom.Storage.(localStorage |> setItem("avatarUrl", avatarUrl));
+      Dom.Storage.(localStorage |> setItem(StorageLabel.keyName, keyName));
+      Dom.Storage.(
+        localStorage |> setItem(StorageLabel.avatarUrl, avatarUrl)
+      );
 
       let account = {keyName, avatarUrl};
       resolve(. Belt.Result.Ok(account));
@@ -24,8 +31,10 @@ let createLocalSource = () => {
 
   let fetchAccount = () =>
     Js.Promise.make((~resolve, ~reject as _) => {
-      let keyName = Dom.Storage.(localStorage |> getItem("keyName"));
-      let avatarUrl = Dom.Storage.(localStorage |> getItem("avatarUrl"));
+      let keyName =
+        Dom.Storage.(localStorage |> getItem(StorageLabel.keyName));
+      let avatarUrl =
+        Dom.Storage.(localStorage |> getItem(StorageLabel.avatarUrl));
 
       let account =
         switch (keyName) {

--- a/app/src/Source.re
+++ b/app/src/Source.re
@@ -13,20 +13,32 @@ type source = {
 };
 
 let createLocalSource = () => {
-  let localAccount = ref(None);
-
   let createAccount = (keyName, avatarUrl) =>
     Js.Promise.make((~resolve, ~reject as _) => {
-      let account = {keyName, avatarUrl};
-      localAccount := Some(account);
+      Dom.Storage.(localStorage |> setItem("keyName", keyName));
+      Dom.Storage.(localStorage |> setItem("avatarUrl", avatarUrl));
 
+      let account = {keyName, avatarUrl};
       resolve(. Belt.Result.Ok(account));
     });
 
   let fetchAccount = () =>
-    Js.Promise.make((~resolve, ~reject as _) =>
-      resolve(. Belt.Result.Ok(localAccount^))
-    );
+    Js.Promise.make((~resolve, ~reject as _) => {
+      let keyName = Dom.Storage.(localStorage |> getItem("keyName"));
+      let avatarUrl = Dom.Storage.(localStorage |> getItem("avatarUrl"));
+
+      let account =
+        switch (keyName) {
+        | None => None
+        | Some(keyName) =>
+          Some({
+            keyName,
+            avatarUrl: Belt.Option.getWithDefault(avatarUrl, ""),
+          })
+        };
+
+      resolve(. Belt.Result.Ok(account));
+    });
 
   {createAccount, fetchAccount};
 };


### PR DESCRIPTION
Until now a page refresh would lose our mock key and the "session" would be lost. This stores the key in localstorage so we can play around with the overall UX of the app until we figure out the real requirements for handling private keys.