### PR TITLE
Make local source default for proxy

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,18 +20,14 @@
   "scripts": {
     "start": "concurrently --kill-others \"yarn bs:clean && yarn bs:watch\" \"wait-on ./lib/js/src/renderer/Index.bs.js && yarn webpack:server\" \"yarn proxy:start\" \"wait-on http://localhost:8000 && wait-on http://localhost:8080 && electron .\"",
     "dist": "rm -rf ./dist && mkdir ./dist && yarn bs:clean && yarn bs:build && yarn webpack:build && yarn proxy:build && cp ../proxy/target/debug/proxy dist && electron-builder",
-
     "test": "yarn bs:build && jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watchAll",
-
     "webpack:server": "webpack-dev-server",
     "webpack:build": "NODE_ENV=production webpack",
-
     "schema:fetch": "yarn send-introspection-query http://localhost:8080/graphql",
-    "proxy:build": "cd ../proxy && cargo build",
-    "proxy:start": "cd ../proxy && cargo run",
-
+    "proxy:build": "cd ../proxy && cargo build --release",
+    "proxy:start": "cd ../proxy && cargo run --release -- local",
     "bs:clean": "bsb -clean-world",
     "bs:build": "bsb -make-world",
     "bs:watch": "bsb -make-world -w"

--- a/app/src/main/Electron.re
+++ b/app/src/main/Electron.re
@@ -28,7 +28,7 @@
   function startProxy() {
     const proxyPath = path.join(__dirname, '../../../../../proxy');
     const { execFile } = require('child_process');
-    proxyChildProcess = execFile(proxyPath, [], (error, stdout, stderr) => {
+    proxyChildProcess = execFile(proxyPath, ['local'], (error, stdout, stderr) => {
       if (error) {
         console.log(error);
       }

--- a/proxy/src/source.rs
+++ b/proxy/src/source.rs
@@ -167,7 +167,6 @@ impl Source for Ledger {
     }
 }
 
-#[cfg(test)]
 pub mod test {
     use std::collections::HashMap;
     use std::sync::{Arc, RwLock};


### PR DESCRIPTION
As the deployment against a running oscoin-parity-etherum instance depends on the exact address of the deployed contract it is hard to bundle this deterministily with the app.